### PR TITLE
bump to rightmesh v0.5.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ preBuild.dependsOn("rightmesh")
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "26.0.2"
+    buildToolsVersion "27.0.3"
     defaultConfig {
         applicationId "io.left.reflect"
         minSdkVersion 14
@@ -76,7 +76,7 @@ dependencies {
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile 'com.android.support:design:27.1.0'
 
-    compile('io.left.rightmesh:rightmesh-library-dev:0.4.4') {
+    compile('io.left.rightmesh:rightmesh-library-dev:0.5.0') {
         transitive true
     }
     compile 'com.android.support:multidex:1.0.3'

--- a/app/src/main/java/io/left/reflect/MainActivity.java
+++ b/app/src/main/java/io/left/reflect/MainActivity.java
@@ -17,14 +17,14 @@ import java.util.Date;
 
 import io.left.rightmesh.android.AndroidMeshManager;
 import io.left.rightmesh.android.MeshService.ServiceDisconnectedException;
-import io.left.rightmesh.id.MeshID;
+import io.left.rightmesh.id.MeshId;
 import io.left.rightmesh.mesh.MeshManager;
 import io.left.rightmesh.mesh.MeshManager.DataReceivedEvent;
 import io.left.rightmesh.mesh.MeshManager.RightMeshEvent;
 import io.left.rightmesh.mesh.MeshStateListener;
 import io.left.rightmesh.util.RightMeshException;
 
-import static io.left.reflect.RightMeshRecipientComponent.shortenMeshID;
+import static io.left.reflect.RightMeshRecipientComponent.shortenMeshId;
 import static io.left.rightmesh.mesh.MeshManager.DATA_RECEIVED;
 import static io.left.rightmesh.mesh.MeshManager.PEER_CHANGED;
 
@@ -32,34 +32,51 @@ import static io.left.rightmesh.mesh.MeshManager.PEER_CHANGED;
  * Simple app for testing RightMesh network reach.
  *
  * <p>
- *     Device A sends a ping to Device B over a mesh network containing a unique message (a
- *     simple timestamp). Device B receives it and echoes it back. Device A displays when the
- *     echoed message is received. This makes it easy to leave a device in one spot, roam around
- *     with another device, and test if the network still works.
+ * Device A sends a ping to Device B over a mesh network containing a unique message (a
+ * simple timestamp). Device B receives it and echoes it back. Device A displays when the
+ * echoed message is received. This makes it easy to leave a device in one spot, roam around
+ * with another device, and test if the network still works.
  * </p>
  */
 public class MainActivity extends AppCompatActivity implements MeshStateListener,
-        RightMeshRecipientComponent.RecipientChangedListener{
+        RightMeshRecipientComponent.RecipientChangedListener {
     private static final String TAG = MainActivity.class.getCanonicalName();
 
-    AndroidMeshManager mm = null;
+    /**
+     * MESH_PORT is the mesh port that this app is allowed to run on, according to your license key.
+     * See developer.rightmesh.io for more details.
+     */
+    private static final int MESH_PORT = 9876;
 
-    // ID of this device, stored for UI use.
-    MeshID deviceID = null;
+    AndroidMeshManager mm;
 
-    // ID of the peer to send pings to.
-    MeshID recipientID = null;
+    // Id of this device, stored for UI use.
+    MeshId deviceId;
+
+    // Id of the peer to send pings to.
+    MeshId recipientId;
 
     // Responsible for allowing the user to select the ping recipient.
-    RightMeshRecipientComponent component = null;
+    RightMeshRecipientComponent component;
 
     // Adapter for tracking views and the spinner it feeds, both mostly powered by `component`.
-    MeshIDAdapter peersListAdapter = null;
-    Spinner peersListView = null;
+    MeshIdAdapter peersListAdapter;
+    Spinner peersListView;
 
     // List and adapter tracking sent pings and whether or not they have been echoed.
-    ArrayList<String> pingsList = new ArrayList<>();
-    ArrayAdapter<String> pingsListAdapter = null;
+    ArrayList<String> pingsList;
+    ArrayAdapter<String> pingsListAdapter;
+
+    public MainActivity() {
+        pingsListAdapter = null;
+        pingsList = new ArrayList<>();
+        peersListView = null;
+        peersListAdapter = null;
+        component = null;
+        recipientId = null;
+        deviceId = null;
+        mm = null;
+    }
 
 
     //
@@ -97,16 +114,16 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
         });
 
         // Set up the recipient selection spinner.
-        peersListAdapter = new MeshIDAdapter(this);
+        peersListAdapter = new MeshIdAdapter(this);
         component = (RightMeshRecipientComponent) getFragmentManager()
                 .findFragmentById(R.id.recipient_component);
         component.setSpinnerAdapter(peersListAdapter);
         component.setOnRecipientChangedListener(this);
-        peersListView = (Spinner) findViewById(R.id.spinner_recipient);
+        peersListView = findViewById(R.id.spinner_recipient);
 
         // Set up the log list.
         pingsListAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, pingsList);
-        ListView log = (ListView) findViewById(R.id.listview_log);
+        ListView log = findViewById(R.id.listview_log);
         log.setAdapter(pingsListAdapter);
 
         // Initialize the mesh.
@@ -148,9 +165,10 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
      */
     private void sendPing(View view) {
         DateFormat df = new SimpleDateFormat("MMM dd kk:mm:ss:SSSS");
+        // DateFormat df = DateFormat.getDateInstance();
 
-        // Null check, as recipientID has no default value.
-        if (recipientID != null) {
+        // Null check, as recipientId has no default value.
+        if (recipientId != null) {
             // Ping content is just the current time, so they are unique and give us some rough
             // concept of delay.
             String timestamp = df.format(new Date());
@@ -158,7 +176,7 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
 
             try {
                 // Attempt to ping the currently selected recipient.
-                mm.sendDataReliable(recipientID, 4321, payload.getBytes());
+                mm.sendDataReliable(recipientId, MESH_PORT, payload.getBytes());
 
                 // Log the ping if sent successfully.
                 pingsList.add(0, timestamp);
@@ -173,15 +191,15 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
     }
 
     /**
-     * Fired by the {@link RightMeshRecipientComponent} when the selected recipient ID has changed.
+     * Fired by the {@link RightMeshRecipientComponent} when the selected recipient Id has changed.
      *
      * <p>Stores the new recipient and updates the display.</p>
      *
      * @param recipient new recipient
      */
     @Override
-    public void onChange(MeshID recipient) {
-        recipientID = recipient;
+    public void onChange(MeshId recipient) {
+        recipientId = recipient;
         updateRecipientColour();
     }
 
@@ -194,26 +212,26 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
      * Configures event handlers, binds to a port, and updates the label when the RightMesh library
      * is ready.
      *
-     * @param meshID ID of this device
-     * @param state new state of the RightMesh library
+     * @param meshId Id of this device
+     * @param state  new state of the RightMesh library
      */
     @Override
-    public void meshStateChanged(MeshID meshID, int state) {
-        deviceID = meshID;
+    public void meshStateChanged(MeshId meshId, int state) {
+        deviceId = meshId;
         if (state == MeshStateListener.SUCCESS) {
             try {
                 // Attempt to bind to a port.
-                MeshManager.Result r = mm.bind(4321);
+                MeshManager.Result r = mm.bind(MESH_PORT);
                 if (r.result == FAILURE) {
                     component.setStatus("Failed to bind.");
                     return;
                 } else {
-                    component.setStatus("This device's ID is " + shortenMeshID(deviceID));
+                    component.setStatus("This device's Id is " + shortenMeshId(deviceId));
                 }
 
-                // Initialize the peer adapter with this device's MeshID.
-                peersListAdapter.add(deviceID);
-                peersListAdapter.setDeviceID(deviceID);
+                // Initialize the peer adapter with this device's MeshId.
+                peersListAdapter.add(deviceId);
+                peersListAdapter.setDeviceId(deviceId);
                 runOnUiThread(() -> peersListAdapter.notifyDataSetChanged());
 
                 // Bind RightMesh event handlers.
@@ -244,8 +262,8 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
             // Echo messages starting with '1'.
             String responsePayload = "0" + dataString.substring(1);
             try {
-                mm.sendDataReliable(dre.peerUuid, 4321, responsePayload.getBytes());
-                pingsList.add(0, "Echoed ping. (" + shortenMeshID(rme.peerUuid) + ")");
+                mm.sendDataReliable(dre.peerUuid, MESH_PORT, responsePayload.getBytes());
+                pingsList.add(0, "Echoed ping. (" + shortenMeshId(rme.peerUuid) + ")");
             } catch (ServiceDisconnectedException sde) {
                 Log.e(TAG, "Service disconnected before ping could be returned, with message: "
                         + sde.getMessage());
@@ -256,7 +274,7 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
             // Messages starting with '0' have already been echoed - update log.
             if (pingsList.contains(timestamp)) {
                 pingsList.set(pingsList.indexOf(timestamp),
-                        timestamp + " - Received! (" + shortenMeshID(rme.peerUuid) + ")");
+                        timestamp + " - Received! (" + shortenMeshId(rme.peerUuid) + ")");
             }
         }
 
@@ -272,7 +290,7 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
      * @param rme event passed from RightMesh
      */
     private void updateColoursOnPeerChanged(RightMeshEvent rme) {
-        if (rme.peerUuid.equals(recipientID)) {
+        if (rme.peerUuid.equals(recipientId)) {
             updateRecipientColour();
         }
     }
@@ -287,9 +305,9 @@ public class MainActivity extends AppCompatActivity implements MeshStateListener
      * blue if the recipient is the current device.
      */
     private void updateRecipientColour() {
-        if (!recipientID.equals(deviceID)) {
+        if (!recipientId.equals(deviceId)) {
             int colour;
-            if (peersListAdapter.contains(recipientID)) {
+            if (peersListAdapter.contains(recipientId)) {
                 colour = R.color.green;
             } else {
                 colour = R.color.red;

--- a/app/src/main/java/io/left/reflect/MeshIdAdapter.java
+++ b/app/src/main/java/io/left/reflect/MeshIdAdapter.java
@@ -8,27 +8,29 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-import io.left.rightmesh.id.MeshID;
+import io.left.rightmesh.id.MeshId;
 
 /**
- * A custom adapter to style the MeshIDs a little nicer in the list.
+ * A custom adapter to style the MeshIds a little nicer in the list.
  */
-class MeshIDAdapter extends ArrayAdapter<MeshID> {
+class MeshIdAdapter extends ArrayAdapter<MeshId> {
 
     /**
      * Inflates the parent {@link ArrayAdapter} and stores the context for use loading colours.
      *
      * @param context app context, need by parent class
      */
-    MeshIDAdapter(@NonNull Context context) {
+    MeshIdAdapter(@NonNull Context context) {
         super(context, android.R.layout.simple_spinner_dropdown_item);
     }
 
-    // ID of the peer to treat as this device (i.e. for styling and naming).
-    private MeshID deviceID;
+    /**
+     * Id of the peer to treat as this device (i.e. for styling and naming).
+     */
+    private MeshId deviceId;
 
-    void setDeviceID(MeshID deviceID) {
-        this.deviceID = deviceID;
+    void setDeviceId(MeshId deviceId) {
+        this.deviceId = deviceId;
     }
 
 
@@ -38,8 +40,7 @@ class MeshIDAdapter extends ArrayAdapter<MeshID> {
 
     /**
      * Returns default view with colour/text modified by
-     * {@link MeshIDAdapter#modifyView(TextView, int)}.
-     *
+     * {@link MeshIdAdapter#modifyView(TextView, int)}.
      * {@inheritDoc}
      */
     @NonNull
@@ -51,8 +52,7 @@ class MeshIDAdapter extends ArrayAdapter<MeshID> {
 
     /**
      * Returns default view with colour/text modified by
-     * {@link MeshIDAdapter#modifyView(TextView, int)}.
-     *
+     * {@link MeshIdAdapter#modifyView(TextView, int)}.
      * {@inheritDoc}
      */
     @Override
@@ -62,26 +62,26 @@ class MeshIDAdapter extends ArrayAdapter<MeshID> {
     }
 
     /**
-     * Update the supplied view with a shortened MeshID string or the special styling for the
+     * Update the supplied view with a shortened MeshId string or the special styling for the
      * current device.
      *
-     * @param view view to be modified
+     * @param view     view to be modified
      * @param position position of the item to be used
      * @return the modified view
      */
     private View modifyView(TextView view, int position) {
-        MeshID item = this.getItem(position);
+        MeshId item = this.getItem(position);
         if (item != null) {
             String text; // Text for the item in the list.
             int colour;  // Colour for the text in the list.
 
-            if (deviceID != null && item.equals(deviceID)) {
-                // Change text colour if is the current device's ID.
+            if (deviceId != null && item.equals(deviceId)) {
+                // Change text colour if is the current device's Id.
                 text = "This Device";
                 colour = R.color.blue;
             } else {
-                // Otherwise, simply make the MeshID more readable and use the theme default colour.
-                text = RightMeshRecipientComponent.shortenMeshID(item);
+                // Otherwise, simply make the MeshId more readable and use the theme default colour.
+                text = RightMeshRecipientComponent.shortenMeshId(item);
                 colour = android.R.color.primary_text_light;
             }
             view.setText(text);
@@ -102,7 +102,7 @@ class MeshIDAdapter extends ArrayAdapter<MeshID> {
      * @param item to check the existence of
      * @return true if the provided item is in the array, false otherwise
      */
-    boolean contains(MeshID item) {
+    boolean contains(MeshId item) {
         return getPosition(item) >= 0; // The position is -1 if it doesn't exist.
     }
 }

--- a/app/src/main/java/io/left/reflect/RightMeshRecipientComponent.java
+++ b/app/src/main/java/io/left/reflect/RightMeshRecipientComponent.java
@@ -11,7 +11,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import io.left.rightmesh.id.MeshID;
+import io.left.rightmesh.id.MeshId;
 import io.left.rightmesh.mesh.MeshManager.PeerChangedEvent;
 import io.left.rightmesh.mesh.MeshManager.RightMeshEvent;
 
@@ -27,7 +27,7 @@ public class RightMeshRecipientComponent extends Fragment
 
     // Keeps track of the most recently tracked recipient, in case it disconnects and is removed
     // from the list.
-    private MeshID recipientID = null;
+    private MeshId recipientId;
 
     // UI Elements
     private Spinner spinner;
@@ -35,9 +35,13 @@ public class RightMeshRecipientComponent extends Fragment
     private TextView networkStatusLabel;
 
     // Keeps track of peers and populates the spinner.
-    private MeshIDAdapter spinnerAdapter;
+    private MeshIdAdapter spinnerAdapter;
 
-    public void setSpinnerAdapter(MeshIDAdapter spinnerAdapter) {
+    public RightMeshRecipientComponent() {
+        recipientId = null;
+    }
+
+    public void setSpinnerAdapter(MeshIdAdapter spinnerAdapter) {
         this.spinnerAdapter = spinnerAdapter;
         spinner.setAdapter(spinnerAdapter);
     }
@@ -61,7 +65,7 @@ public class RightMeshRecipientComponent extends Fragment
      * of this fragment.
      */
     interface RecipientChangedListener {
-        void onChange(MeshID recipient);
+        void onChange(MeshId recipient);
     }
 
     private RecipientChangedListener onRecipientChangedListener = null;
@@ -77,15 +81,15 @@ public class RightMeshRecipientComponent extends Fragment
 
 
     //
-    // ANDROID EVENT HANDLING
+    // ANDROId EVENT HANDLING
     //
 
     /**
      * When the view is created, inflate the layout, save references to all of the elements, and
      * set the spinner event listener.
      *
-     * @param inflater to inflate the layout
-     * @param container to inflate the layout
+     * @param inflater           to inflate the layout
+     * @param container          to inflate the layout
      * @param savedInstanceState passed by Android
      * @return the inflated view
      */
@@ -95,11 +99,11 @@ public class RightMeshRecipientComponent extends Fragment
         super.onCreateView(inflater, container, savedInstanceState);
         View rootView = inflater.inflate(R.layout.component_rightmesh, container);
 
-        spinner = (Spinner) rootView.findViewById(R.id.spinner_recipient);
+        spinner = rootView.findViewById(R.id.spinner_recipient);
         spinner.setOnItemSelectedListener(this);
 
-        deviceStatusLabel = (TextView) rootView.findViewById(R.id.textView_deviceStatus);
-        networkStatusLabel = (TextView) rootView.findViewById(R.id.textView_networkStatus);
+        deviceStatusLabel = rootView.findViewById(R.id.textView_deviceStatus);
+        networkStatusLabel = rootView.findViewById(R.id.textView_networkStatus);
 
         return rootView;
     }
@@ -108,15 +112,15 @@ public class RightMeshRecipientComponent extends Fragment
      * When the selected item in the recipient selection spinner changes, update the local variable
      * and notify the listener.
      *
-     * @param parent the spinner
-     * @param view view of the selected peer
+     * @param parent   the spinner
+     * @param view     view of the selected peer
      * @param position position of the selected peer in the list, used to get the actual object
-     * @param id passed by Android
+     * @param id       passed by Android
      */
     @Override
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        recipientID = spinnerAdapter.getItem(position);
-        onRecipientChangedListener.onChange(recipientID);
+        recipientId = spinnerAdapter.getItem(position);
+        onRecipientChangedListener.onChange(recipientId);
     }
 
     /**
@@ -145,7 +149,7 @@ public class RightMeshRecipientComponent extends Fragment
      */
     public void updatePeersList(RightMeshEvent rme) {
         PeerChangedEvent pce = (PeerChangedEvent) rme;
-        MeshID peer = rme.peerUuid;
+        MeshId peer = rme.peerUuid;
 
         if (pce.state == ADDED && !spinnerAdapter.contains(peer)) {
             // Add the peer to the list if it is new.
@@ -161,7 +165,7 @@ public class RightMeshRecipientComponent extends Fragment
             spinnerAdapter.remove(peer);
 
             // Toast if the recipient has been disconnected.
-            if (peer.equals(recipientID)) {
+            if (peer.equals(recipientId)) {
                 Toast.makeText(getActivity().getApplicationContext(),
                         "Recipient has disconnected.", Toast.LENGTH_SHORT).show();
             }
@@ -172,7 +176,7 @@ public class RightMeshRecipientComponent extends Fragment
         if (parentActivity != null) {
             if (spinnerAdapter.getCount() > 1) {
                 // Get string resource with number of connected devices.
-                int numConnectedDevices = spinnerAdapter.getCount()-1;
+                int numConnectedDevices = spinnerAdapter.getCount() - 1;
                 String newText = getResources().getQuantityString(
                         R.plurals.number_of_connected_devices,
                         numConnectedDevices, numConnectedDevices);
@@ -190,12 +194,12 @@ public class RightMeshRecipientComponent extends Fragment
     //
 
     /**
-     * Truncates MeshIDs to 8 characters long.
+     * Truncates MeshIds to 8 characters long.
      *
      * @param id to get string of
      * @return truncated string
      */
-    static String shortenMeshID(MeshID id) {
+    static String shortenMeshId(MeshId id) {
         return id.toString().substring(0, 10) + "...";
     }
 }


### PR DESCRIPTION
Version bump:
 - Updated from v0.4.4 to v0.5.0
 - Changed all instances of `MeshID` to `MeshId`
   + Globally replaced "ID" with "Id" to reflect this change

Minor change:
 - Removed "magic constants" and introduced a MESH_PORT constant in
   MainActivity.java
 - Moved direct field assignment to constructor, per IntelliJ recommendations

Tested in small master-client mesh.